### PR TITLE
Define custom process_results for all masakhapos prompts

### DIFF
--- a/lm_eval/tasks/afrobench/masakhapos/prompt_1/masakhapos_yaml
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_1/masakhapos_yaml
@@ -14,6 +14,7 @@ validation_split: validation
 test_split: test
 fewshot_split: train
 doc_to_target: !function utils.doc_to_target
+process_results: !function utils.process_results
 should_decontaminate: true
 doc_to_decontamination_query: "Sentence: {{token}}\nOutput:"
 filter_list:

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_1/utils.py
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_1/utils.py
@@ -29,6 +29,12 @@ def doc_to_target(doc):
     return [pos_tag_map[tag] for tag in doc["upos"]]
 
 
+def process_results(doc, results):
+    gold = doc_to_target(doc)
+    preds = results
+    return {"acc": (gold, preds)}
+
+
 def acc_score(items):
     unzipped_list = list(zip(*items))
 

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_2/masakhapos_yaml
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_2/masakhapos_yaml
@@ -14,6 +14,7 @@ validation_split: validation
 test_split: test
 fewshot_split: train
 doc_to_target: !function utils.doc_to_target
+process_results: !function utils.process_results
 should_decontaminate: true
 doc_to_decontamination_query: "Sentence: {{token}}\nOutput:"
 filter_list:

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_2/utils.py
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_2/utils.py
@@ -29,6 +29,12 @@ def doc_to_target(doc):
     return [pos_tag_map[tag] for tag in doc["upos"]]
 
 
+def process_results(doc, results):
+    gold = doc_to_target(doc)
+    preds = results
+    return {"acc": (gold, preds)}
+
+
 def acc_score(items):
     unzipped_list = list(zip(*items))
 

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_3/masakhapos_yaml
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_3/masakhapos_yaml
@@ -14,6 +14,7 @@ validation_split: validation
 test_split: test
 fewshot_split: train
 doc_to_target: !function utils.doc_to_target
+process_results: !function utils.process_results
 should_decontaminate: true
 doc_to_decontamination_query: "Sentence: {{token}}\nOutput:"
 filter_list:

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_3/utils.py
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_3/utils.py
@@ -29,6 +29,12 @@ def doc_to_target(doc):
     return [pos_tag_map[tag] for tag in doc["upos"]]
 
 
+def process_results(doc, results):
+    gold = doc_to_target(doc)
+    preds = results
+    return {"acc": (gold, preds)}
+
+
 def acc_score(items):
     unzipped_list = list(zip(*items))
 

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_4/masakhapos_yaml
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_4/masakhapos_yaml
@@ -14,6 +14,7 @@ validation_split: validation
 test_split: test
 fewshot_split: train
 doc_to_target: !function utils.doc_to_target
+process_results: !function utils.process_results
 should_decontaminate: true
 doc_to_decontamination_query: "Sentence: {{token}}\nOutput:"
 filter_list:

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_4/utils.py
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_4/utils.py
@@ -29,6 +29,12 @@ def doc_to_target(doc):
     return [pos_tag_map[tag] for tag in doc["upos"]]
 
 
+def process_results(doc, results):
+    gold = doc_to_target(doc)
+    preds = results
+    return {"acc": (gold, preds)}
+
+
 def acc_score(items):
     unzipped_list = list(zip(*items))
 

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_5/masakhapos_yaml
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_5/masakhapos_yaml
@@ -14,6 +14,7 @@ validation_split: validation
 test_split: test
 fewshot_split: train
 doc_to_target: !function utils.doc_to_target
+process_results: !function utils.process_results
 should_decontaminate: true
 doc_to_decontamination_query: "Sentence: {{token}}\nOutput:"
 filter_list:

--- a/lm_eval/tasks/afrobench/masakhapos/prompt_5/utils.py
+++ b/lm_eval/tasks/afrobench/masakhapos/prompt_5/utils.py
@@ -29,6 +29,12 @@ def doc_to_target(doc):
     return [pos_tag_map[tag] for tag in doc["upos"]]
 
 
+def process_results(doc, results):
+    gold = doc_to_target(doc)
+    preds = results
+    return {"acc": (gold, preds)}
+
+
 def acc_score(items):
     unzipped_list = list(zip(*items))
 


### PR DESCRIPTION
## Summary
- pass gold tags and model predictions to accuracy aggregator for masakhapos prompts
- configure each masakhapos prompt to call the new process_results hook

## Testing
- `pytest tests/test_cli.py::test_cli_parse_error -q`
- `pre-commit run --files lm_eval/tasks/afrobench/masakhapos/prompt_1/utils.py lm_eval/tasks/afrobench/masakhapos/prompt_1/masakhapos_yaml lm_eval/tasks/afrobench/masakhapos/prompt_2/utils.py lm_eval/tasks/afrobench/masakhapos/prompt_2/masakhapos_yaml lm_eval/tasks/afrobench/masakhapos/prompt_3/utils.py lm_eval/tasks/afrobench/masakhapos/prompt_3/masakhapos_yaml lm_eval/tasks/afrobench/masakhapos/prompt_4/utils.py lm_eval/tasks/afrobench/masakhapos/prompt_4/masakhapos_yaml lm_eval/tasks/afrobench/masakhapos/prompt_5/utils.py lm_eval/tasks/afrobench/masakhapos/prompt_5/masakhapos_yaml` *(fails: No module named pre_commit)*

Fixes https://github.com/EleutherAI/lm-evaluation-harness/issues/3260

------
https://chatgpt.com/codex/tasks/task_e_68ac68a51898832393ecdc9dfa3510a2